### PR TITLE
Create manifest during Now deployments and store within .next folder

### DIFF
--- a/buildManifest.js
+++ b/buildManifest.js
@@ -6,11 +6,11 @@ const pwaManifestIcons = require('@pwa/manifest-icons');
 
 module.exports = ({
   isServer,
-  runInDevMode,
+  buildInDevMode,
   manifest,
   outputDirector
 }) => {
-  if (!isServer && runInDevMode) {
+  if (!isServer && buildInDevMode) {
     const m = pwaManifest.sync({
       "background_color": "#FFFFFF",
       "theme_color": "#FFFFFF",

--- a/buildManifest.js
+++ b/buildManifest.js
@@ -1,0 +1,34 @@
+const {
+  join
+} = require('path');
+const pwaManifest = require('@pwa/manifest');
+const pwaManifestIcons = require('@pwa/manifest-icons');
+
+module.exports = ({
+  isServer,
+  runInDevMode,
+  manifest,
+  outputDirector
+}) => {
+  if (!isServer && runInDevMode) {
+    const m = pwaManifest.sync({
+      "background_color": "#FFFFFF",
+      "theme_color": "#FFFFFF",
+      "start_url": "/?utm_source=web_app_manifest",
+      ...manifest
+    });
+
+    if (manifest.icons && manifest.icons.src) {
+      m.icons = pwaManifestIcons.sync({
+        src: manifest.icons.src,
+        cache: manifest.icons.cache || false,
+        output: join(outputDirector, 'static/manifest/icons'),
+        publicPath: '/static/manifest/icons/',
+        sizes: manifest.icons.sizes || [192, 512]
+
+      });
+    }
+
+    pwaManifest.writeSync(join(outputDirector, 'static/manifest/'), m);
+  }
+}

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = (nextConfig = {}) => {
       config.plugins.push(
         new NextManifestPlugin({
           isServer,
-          runInDevMode: manifest.runInDevMode || !dev,
+          buildInDevMode: manifest.buildInDevMode || !dev,
           manifest,
           outputDirector: config.output.path,
         })

--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
-const {resolve} = require('path');
-const pwaManifest = require('@pwa/manifest');
-const pwaManifestIcons = require('@pwa/manifest-icons');
+const NextManifestPlugin = require('./plugin');
 
 module.exports = (nextConfig = {}) => {
   return Object.assign({}, nextConfig, {
@@ -10,9 +8,6 @@ module.exports = (nextConfig = {}) => {
         dev,
         buildId,
         defaultLoaders,
-        config: {
-          distDir
-        }
       } = options
 
       if (!defaultLoaders) {
@@ -21,29 +16,19 @@ module.exports = (nextConfig = {}) => {
         )
       }
 
-      const {webpack, manifest} = nextConfig;
+      const {
+        webpack,
+        manifest
+      } = nextConfig;
 
-      if (!isServer && !dev) {
-        const m = pwaManifest.sync({
-          "background_color": "#FFFFFF",
-          "theme_color": "#FFFFFF",
-          "start_url": "/?utm_source=web_app_manifest",
-          ...manifest
-        });
-
-        if (manifest.icons && manifest.icons.src) {
-          m.icons = pwaManifestIcons.sync({
-            src: manifest.icons.src,
-            cache: manifest.icons.cache || false,
-            output: resolve(process.cwd(), `./static/manifest/icons`),
-            publicPath: '/static/manifest/icons/',
-            sizes: manifest.icons.sizes || [192, 512]
-
-          });
-        }
-
-        pwaManifest.writeSync('./static/manifest/', m);
-      }
+      config.plugins.push(
+        new NextManifestPlugin({
+          isServer,
+          runInDevMode: manifest.runInDevMode || !dev,
+          manifest,
+          outputDirector: config.output.path,
+        })
+      );
 
       if (typeof webpack === 'function') {
         return webpack(config, options);

--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,27 @@
+const buildManifest = require('./buildManifest');
+
+module.exports = class NextManifestPlugin {
+  constructor(options) {
+    this.options = options;
+  }
+
+  apply(compiler) {
+    const errorhandler = err => {
+      throw new Error(`Precached failed: ${err.toString()}`);
+    };
+
+    if (compiler.hooks) {
+      compiler.hooks.done.tap(
+        'CopyPlugin',
+        async () => buildManifest(this.options),
+          errorhandler
+      );
+    } else {
+      compiler.plugin(
+        'done',
+        async () => buildManifest(this.options),
+          errorhandler
+      );
+    }
+  }
+}


### PR DESCRIPTION
This resolves issue #11 

- Project structure updated to be similar to next-offline (https://github.com/hanford/next-offline)
- Manifest now runs on Webpacks `done` hook, making next-manifest generate a manifest on now deployments and when using `now dev`
- new config option added `buildInDevMode` allowing the manifest to be generated when in dev mode
- moved output to .next directory as this is where other plugin store files generated at build time